### PR TITLE
Fix photometry tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 See [semantic versioning](https://semver.org/spec/v2.0.0.html) for the rationale behind
 the version numbers.
 
-<!-- ## [1.1.0](https://github.com/CASTOR-telescope/ETC_frontend/tree/v1.1.0) (2022-mm-dd)
+<!-- ## [1.x.0](https://github.com/CASTOR-telescope/ETC_frontend/tree/v1.1.0) (2022-mm-dd)
 
 - Also, we now only render the spectrum for wavelengths within the CASTOR passband
 ranges. This should allow users to upload bigger spectra without hitting the session
@@ -11,12 +11,40 @@ storage limit. See the comments beginning
 [here](https://github.com/CASTOR-telescope/ETC_frontend/issues/2#issuecomment-1125563805)
 for more context/details. -->
 
+## [1.1.1](https://github.com/CASTOR-telescope/ETC_frontend/tree/v1.1.1) (2024-01-02)
+
+- Fixed the photometry tab. Previous errors caused by the backend being out-of-date with
+  respect to the [Python ETC](https://github.com/CASTOR-telescope/ETC). This is fixed as
+  of [`castor_etc` v1.3.1](https://github.com/CASTOR-telescope/ETC/tree/v1.3.1).
+  - Added radio buttons to select which passband to render the source through, and updated
+    the plot labels accordingly
+  - Moved encircled energy into results table. The table now reports the encircled energy
+    in each passband for the selected aperture
+
+## [1.1.0](https://github.com/CASTOR-telescope/ETC_frontend/tree/v1.1.0) (2023-11-13)
+
+- Added UVMOS spectroscopy tab capable of simulating:
+  - Source viewed on the detector
+  - Source viewed through the slit
+  - Flux (counts/second) spectra
+- Added GRISM spectroscopy tab capable of simulating:
+  - 2D Signal-Noise ratio (SNR) per resolution
+  - 1D SNR per resolution
+- Added Transit simulation tab capable of simulating:
+  - Scene
+  - Lightcurve
+- NOTE: the photometry tab is out-of-date and non-functional (see
+  [this comment on #10](https://github.com/CASTOR-telescope/ETC_frontend/pull/10#discussion_r1392001823)).
+  This will be fixed in the next update
+  - For now, users should use the [Python ETC](https://github.com/CASTOR-telescope/ETC)
+    for synthetic photometry
+
 ## [1.0.1](https://github.com/CASTOR-telescope/ETC_frontend/tree/v1.0.1) (2022-05-13)
 
 - Added `git` to Dockerfile
 - Reset custom spectrum value upon loading of Source form
-- Fixed 500 error when uploading spectrum from a FITS file
-  (PR [#3](https://github.com/CASTOR-telescope/ETC_frontend/pull/3))
+- Fixed 500 error when uploading spectrum from a FITS file (PR
+  [#3](https://github.com/CASTOR-telescope/ETC_frontend/pull/3))
 - Fix typo in Photometry results tab (issue
   [#4](https://github.com/CASTOR-telescope/ETC_frontend/issues/4) fixed by PR
   [#5](https://github.com/CASTOR-telescope/ETC_frontend/pull/5))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ for more context/details. -->
 
 ## [1.1.1](https://github.com/CASTOR-telescope/ETC_frontend/tree/v1.1.1) (2024-01-02)
 
-- Fixed the photometry tab. Previous errors caused by the backend being out-of-date with
-  respect to the [Python ETC](https://github.com/CASTOR-telescope/ETC). This is fixed as
-  of [`castor_etc` v1.3.1](https://github.com/CASTOR-telescope/ETC/tree/v1.3.1).
+- Fixed the photometry tab (PR
+  [#24](https://github.com/CASTOR-telescope/ETC_frontend/pull/24)). Previous errors caused
+  by the backend being out-of-date with respect to the
+  [Python ETC](https://github.com/CASTOR-telescope/ETC). This is fixed as of
+  [`castor_etc` v1.3.1](https://github.com/CASTOR-telescope/ETC/tree/v1.3.1).
   - Added radio buttons to select which passband to render the source through, and updated
     the plot labels accordingly
   - Moved encircled energy into results table. The table now reports the encircled energy

--- a/frontend/src/components/forms/PhotometryForm.tsx
+++ b/frontend/src/components/forms/PhotometryForm.tsx
@@ -330,22 +330,6 @@ const ApertureGroup: React.FC<ApertureGroupProps> = ({
           }
         })() // calling anonymous arrow function to render it
       }
-      {isPointSource &&
-        (values.aperShape === Apertures.Elliptical ||
-          values.aperShape === Apertures.Rectangular) && (
-          <FormHelperText
-            sx={{
-              fontSize: "medium",
-              fontWeight: "normal",
-              marginBottom: 2,
-              textAlign: "center",
-            }}
-          >
-            Note that the point source's encircled energy within an elliptical or
-            rectangular aperture is calculated using a Monte Carlo integration and is not
-            an exact value.
-          </FormHelperText>
-        )}
     </FormControl>
   );
 };
@@ -396,6 +380,77 @@ const ReddeningGroup: React.FC<ReddeningGroupProps> = ({ values }) => {
         label="E(B-V)"
         required={true}
       />
+    </FormControl>
+  );
+};
+
+enum SourceWeightsPassbands {
+  Noiseless = "noiseless",
+  Uv = "uv",
+  U = "u",
+  G = "g",
+}
+
+type SourceWeightsPassbandGroupProps = {
+  values: { [value: string]: any }; // any object props
+} & FieldAttributes<{}>;
+
+const SourceWeightsPassbandGroup: React.FC<SourceWeightsPassbandGroupProps> = ({
+  values,
+}) => {
+  const { setFieldValue } = useFormikContext();
+
+  return (
+    <FormControl component="fieldset" variant="standard" fullWidth={true}>
+      <FormLabel component="legend" required={true} sx={{ fontSize: 17.5 }} filled={true}>
+        Passband for Source Visualization
+      </FormLabel>
+      <FormHelperText
+        sx={{
+          fontSize: "medium",
+          fontWeight: "normal",
+          marginTop: 0,
+          marginBottom: 2,
+          textAlign: "center",
+        }}
+      >
+        Select the passband through which the source will be rendered. The rendered image
+        will be the raw surface brightness profile of the source convolved with the
+        selected passband's PSF. Selecting "Noiseless" will render the source without PSF
+        convolution.
+      </FormHelperText>
+      <RadioGroup
+        name={"sourceWeightsPassband"}
+        value={values.sourceWeightsPassband}
+        // Need to set onChange manually in this case
+        // See <https://levelup.gitconnected.com/create-a-controlled-radio-group-in-react-formik-material-ui-and-typescript-7ed314081a0e>
+        onChange={(event) => {
+          setFieldValue("sourceWeightsPassband", event.currentTarget.value);
+        }}
+        sx={{ marginBottom: 2, justifyContent: "center" }}
+        row
+      >
+        <FormControlLabel
+          value={SourceWeightsPassbands.Noiseless}
+          control={<Radio />}
+          label="Noiseless"
+        />
+        <FormControlLabel
+          value={SourceWeightsPassbands.Uv}
+          control={<Radio />}
+          label="UV-Band"
+        />
+        <FormControlLabel
+          value={SourceWeightsPassbands.U}
+          control={<Radio />}
+          label="u-Band"
+        />
+        <FormControlLabel
+          value={SourceWeightsPassbands.G}
+          control={<Radio />}
+          label="g-Band"
+        />
+      </RadioGroup>
     </FormControl>
   );
 };
@@ -568,23 +623,6 @@ const DisplayResults: React.FC<{ numPhotometrySubmit: number }> = ({
         of that passband's red leak to the total passband response (in electrons per
         second) induced by the entire spectrum.
       </Typography>
-      {photParams["encircledEnergy"] !== null && (
-        <div style={divStyle}>
-          <Typography
-            component={Paper}
-            sx={{
-              fontSize: tableHeadFontSize,
-              marginBottom: 1,
-              padding: 1,
-              ...paperSx,
-            }}
-          >
-            <b>Point source encircled energy fraction:</b>{" "}
-            {(100 * photParams["encircledEnergy"]).toFixed(2)}%
-          </Typography>
-          <br />
-        </div>
-      )}
       <div style={divStyle}>
         <Typography
           component={Paper}
@@ -612,6 +650,9 @@ const DisplayResults: React.FC<{ numPhotometrySubmit: number }> = ({
                   Passband
                 </TableCell>
                 <TableCell sx={{ fontSize: tableHeadFontSize }} align="right">
+                  Encircled&nbsp;Energy&nbsp;%
+                </TableCell>
+                <TableCell sx={{ fontSize: tableHeadFontSize }} align="right">
                   Red&nbsp;Leak&nbsp;Fraction
                 </TableCell>
                 <TableCell sx={{ fontSize: tableHeadFontSize }} align="right">
@@ -637,6 +678,7 @@ const DisplayResults: React.FC<{ numPhotometrySubmit: number }> = ({
                     >
                       UV
                     </TableCell>
+                    {resultCell(100 * photParams["encircledEnergies"]["uv"])}
                     {resultCell(redleakFracUv)}
                     <TableCell sx={{ fontSize: tableCellFontSize }} align="right">
                       {photForm["photInput"].val}
@@ -654,6 +696,7 @@ const DisplayResults: React.FC<{ numPhotometrySubmit: number }> = ({
                     >
                       u
                     </TableCell>
+                    {resultCell(100 * photParams["encircledEnergies"]["u"])}
                     {resultCell(redleakFracU)}
                     <TableCell sx={{ fontSize: tableCellFontSize }} align="right">
                       {photForm["photInput"].val}
@@ -671,6 +714,7 @@ const DisplayResults: React.FC<{ numPhotometrySubmit: number }> = ({
                     >
                       g
                     </TableCell>
+                    {resultCell(100 * photParams["encircledEnergies"]["g"])}
                     {resultCell(redleakFracG)}
                     <TableCell sx={{ fontSize: tableCellFontSize }} align="right">
                       {photForm["photInput"].val}
@@ -692,6 +736,7 @@ const DisplayResults: React.FC<{ numPhotometrySubmit: number }> = ({
                     >
                       UV
                     </TableCell>
+                    {resultCell(100 * photParams["encircledEnergies"]["uv"])}
                     {resultCell(redleakFracUv)}
                     {resultCell(photResultsUv)}
                     <TableCell sx={{ fontSize: tableCellFontSize }} align="right">
@@ -709,6 +754,7 @@ const DisplayResults: React.FC<{ numPhotometrySubmit: number }> = ({
                     >
                       u
                     </TableCell>
+                    {resultCell(100 * photParams["encircledEnergies"]["u"])}
                     {resultCell(redleakFracU)}
                     {resultCell(photResultsU)}
                     <TableCell sx={{ fontSize: tableCellFontSize }} align="right">
@@ -726,6 +772,7 @@ const DisplayResults: React.FC<{ numPhotometrySubmit: number }> = ({
                     >
                       g
                     </TableCell>
+                    {resultCell(100 * photParams["encircledEnergies"]["g"])}
                     {resultCell(redleakFracG)}
                     {resultCell(photResultsG)}
                     <TableCell sx={{ fontSize: tableCellFontSize }} align="right">
@@ -743,6 +790,7 @@ const DisplayResults: React.FC<{ numPhotometrySubmit: number }> = ({
 
 const photometryValidationSchema = Yup.object({
   aperShape: Yup.string().oneOf(Object.values(Apertures)),
+  sourceWeightsPassband: Yup.string().oneOf(Object.values(SourceWeightsPassbands)),
   reddening: Yup.number()
     .required("Reddening is a required field")
     .typeError("Reddening must be a non-negative number")
@@ -894,6 +942,7 @@ const PhotometryForm: React.FC<PhotometryFormProps> = ({
     }
 
     myInitialValues = {
+      sourceWeightsPassband: SourceWeightsPassbands.Noiseless,
       reddening: "0", // E(B-V)
       aperShape: initialAperShape,
       aperParams: {
@@ -1012,6 +1061,10 @@ const PhotometryForm: React.FC<PhotometryFormProps> = ({
             />
             <br />
             <ReddeningGroup name="ReddeningGroupThisNameIsNotUsed" values={values} />
+            <SourceWeightsPassbandGroup
+              name="SourceWeightsPassbandGroupThisNameIsNotUsed"
+              values={values}
+            />
             <FormControl
               component="fieldset"
               variant="standard"

--- a/frontend/src/components/forms/PhotometryForm.tsx
+++ b/frontend/src/components/forms/PhotometryForm.tsx
@@ -937,7 +937,6 @@ const PhotometryForm: React.FC<PhotometryFormProps> = ({
   return (
     <div>
       <Typography variant="h5">Make a photometry calculation below.</Typography>
-      <Typography variant="h6" color="#ff0000">This tab is currently out-of-date and non-functional. For now, please  use the Python ETC for synthetic photometry.</Typography>
       <Typography variant="body1" style={{ marginBottom: 16 }}>
         <b>
           Form validation is still in development for this tab. Please ensure all inputs

--- a/frontend/src/components/plots/SourceWeightsPlot.tsx
+++ b/frontend/src/components/plots/SourceWeightsPlot.tsx
@@ -81,7 +81,17 @@ const SourceWeightsPlot: React.FC<SourceWeightsPlotProps> = ({ numPhotometrySubm
   if (sessionStorage.getItem("photometryParams") !== null) {
     // Update to proper sessionStorage key after
     let photometryParams = JSON.parse(`${sessionStorage.getItem("photometryParams")}`);
-    let sourceWeights = JSON.parse(photometryParams["sourceWeights"]); // need to parse twice...
+    let sourceWeights = JSON.parse(photometryParams["sourceWeights"]); // need to JSON parse twice...
+    let photometryForm = JSON.parse(`${sessionStorage.getItem("photometryForm")}`);
+    let sourceWeightsPassband = photometryForm["sourceWeightsPassband"];
+    let sourceWeightsPassbandText = "";
+    if (sourceWeightsPassband === "noiseless") {
+      sourceWeightsPassbandText = "Source Without PSF Convolution";
+    } else if (sourceWeightsPassband === "uv") {
+      sourceWeightsPassbandText = `Source In UV-Band`;
+    } else {
+      sourceWeightsPassbandText = `Source In ${sourceWeightsPassband}-Band`;
+    }
     // let zauto = true;
     // let zmax = 0; // only relevant if zauto is false (i.e., for log color scale)
     // let zmin = 0; // only relevant if zauto is false (i.e., for log color scale)
@@ -123,7 +133,7 @@ const SourceWeightsPlot: React.FC<SourceWeightsPlotProps> = ({ numPhotometrySubm
             colorscale: "Electric",
             colorbar: {
               title: {
-                text: "Flux Relative to Source Center (incl. fractional pixels)",
+                text: "Percent of Source Flux Contained in Pixel",
                 side: "right",
                 font: { size: 14 },
               },
@@ -139,10 +149,10 @@ const SourceWeightsPlot: React.FC<SourceWeightsPlotProps> = ({ numPhotometrySubm
           },
         ]}
         layout={{
-          // title: {
-          //   text: "Effective No. of Pixels: " + Math.round(100 * effNpix) / 100,
-          //   font: { size: 18 },
-          // },
+          title: {
+            text: sourceWeightsPassbandText,
+            font: { color: "white", size: 17.5 },
+          },
           font: { color: "white", size: 14 },
           autosize: true,
           paper_bgcolor: themeBackgroundColor,
@@ -183,7 +193,7 @@ const SourceWeightsPlot: React.FC<SourceWeightsPlotProps> = ({ numPhotometrySubm
         divId={`source-weights-plot-${numPhotometrySubmit}`}
         data={[]}
         layout={{
-          title: "(Relative Source Flux in Aperture)",
+          title: "(Percent of Source Flux Contained in Pixel)",
           font: { color: "white", size: 14 },
           autosize: true,
           paper_bgcolor: themeBackgroundColor,


### PR DESCRIPTION
This PR fixes the photometry tab caused by the GUI backend being out-of-date with respect to the Python ETC.

Since we now have PSFs for the telescope's passbands, the encircled energy and the mock source rendering will be different in each passband. Thus, In addition to fixing the GUI to work with [`castor_etc` v.1.3.1](https://github.com/CASTOR-telescope/ETC/tree/v1.3.1), I've also implemented 2 other changes:
1. I moved the encircled energy result into the table at the bottom of the photometry tab, which now shows the encircled energy in the aperture for each passband.
2. I added radio buttons to select which passband to visualize the source through, as the different PSFs lead to different images of the source through different passbands.

Following is a screenshot of the GUI showing these changes (the top portion of the left panel isn't shown because I had to scroll down):
![image](https://github.com/CASTOR-telescope/ETC_frontend/assets/64443273/853f2f20-655a-4560-85af-1949837bb42c)

